### PR TITLE
Allow spaces in envvar values

### DIFF
--- a/envcrypt.go
+++ b/envcrypt.go
@@ -25,9 +25,17 @@ func decrypt(path string) ([]byte, error) {
 	return out, nil
 }
 
+func isNewLine(r rune) bool {
+	switch r {
+	case '\n':
+		return true
+	}
+	return false
+}
+
 // The parse function splits a byte array on whitespace.
 func parse(data []byte) ([]string, error) {
-	return strings.Fields(string(data)), nil
+	return strings.FieldsFunc(string(data), isNewLine), nil
 }
 
 // The run function runs a command in an environment.

--- a/envcrypt_test.go
+++ b/envcrypt_test.go
@@ -11,3 +11,11 @@ func TestParseOK(t *testing.T) {
 		t.Errorf("")
 	}
 }
+
+func TestParseSpaces(t *testing.T) {
+	in := []byte("FOO=bar baz\n")
+	out := []string{"FOO=bar baz"}
+	if result, _ := parse(in); result[0] != out[0] {
+		t.Errorf("")
+	}
+}


### PR DESCRIPTION
`strings.Fields` will split on any space, including space inside environment
variable values. This precludes the reasonable use of such values.

Now, define a func (`isNewLine`) and use `strings.FieldsFunc` to split 
explicitly on newlines. Update tests to demonstrate fix.

Reported and proposed by @jklukas in #4.
